### PR TITLE
Add transaction sum

### DIFF
--- a/budget-buddy/user_dashboard/models.py
+++ b/budget-buddy/user_dashboard/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models import Sum 
 from users.models import CustomUser
 
 class UserDashboard(models.Model):
@@ -15,7 +16,14 @@ class UserDashboard(models.Model):
         budget = self.salary * (self.saving_percentage / 100)
         # You can add more calculations based on your specific requirements
         return budget
-
+    
+    def total_amount_for_user(self):
+        total = 0
+        transactions = Transaction.objects.filter(user=self.custom_user)
+        for transaction in transactions:
+            total += transaction.amount
+        return total
+    
     def save(self, *args, **kwargs):
         # Calculate and update spending when saving UserDashboard instance
         self.spending = self.calculate_budget()
@@ -52,3 +60,6 @@ class Transaction(models.Model):
 
     def get_category(self):
         return str(self.category.name)
+    
+
+    

--- a/budget-buddy/user_dashboard/templates/user_dash.html
+++ b/budget-buddy/user_dashboard/templates/user_dash.html
@@ -21,6 +21,7 @@
               <li class="list-group-item text-light">Saving Percentage: {{ dashboard.saving_percentage }}%</li>
               <li class="list-group-item text-light">Fixed Percentage: {{ dashboard.fixed_percentage }}%</li>
               <li class="list-group-item text-light">Available to Spend: ${{ dashboard.spending|floatformat:2|intcomma }}</li>
+              <li class="list-group-item text-light">Total Money Spent: ${{ total_amount|floatformat:2|intcomma }}</li>
             </ul>
             <a href="{% url 'update_information' %}" class="btn btn-primary btn-sm mt-4">Update Information</a>
           </div>
@@ -30,7 +31,7 @@
         <div class="card mb-4">
           <div class="card-body">
             <h3 class="card-title">Your Tracked Expense Categories</h3>
-            <ul class="list-group mb-4"  style="height: 195px; overflow-y: auto;">
+            <ul class="list-group mb-4"  style="height: 196px; overflow-y: auto;">
               {% for c in categories %}
               <li class="list-group-item text-light">{{ c }}</li>
               {% endfor %}

--- a/budget-buddy/user_dashboard/templates/user_dash.html
+++ b/budget-buddy/user_dashboard/templates/user_dash.html
@@ -13,9 +13,9 @@
       <!-- Left Column -->
       <div class="col-md-6">
         <!-- Account Overview Card -->
-        <div class="card mb-4">
+        <div class="card mb-3">
           <div class="card-body">
-            <h3 class="card-title">Account Overview:</h3>
+            <h4 class="card-title">Account Overview:</h4>
             <ul class="list-group">
               <li class="list-group-item text-light">Salary: ${{ dashboard.salary|floatformat:2|intcomma }}</li>
               <li class="list-group-item text-light">Saving Percentage: {{ dashboard.saving_percentage }}%</li>
@@ -23,15 +23,15 @@
               <li class="list-group-item text-light">Available to Spend: ${{ dashboard.spending|floatformat:2|intcomma }}</li>
               <li class="list-group-item text-light">Total Money Spent: ${{ total_amount|floatformat:2|intcomma }}</li>
             </ul>
-            <a href="{% url 'update_information' %}" class="btn btn-primary btn-sm mt-4">Update Information</a>
+            <a href="{% url 'update_information' %}" class="btn btn-primary btn-sm mt-2">Update Information</a>
           </div>
         </div>
         
         <!-- Tracked Categories Card -->
-        <div class="card mb-4">
+        <div class="card mb-2">
           <div class="card-body">
-            <h3 class="card-title">Your Tracked Expense Categories</h3>
-            <ul class="list-group mb-4"  style="height: 196px; overflow-y: auto;">
+            <h4 class="card-title">Your Tracked Expense Categories</h4>
+            <ul class="list-group mb-2"  style="height: 201px; overflow-y: auto;">
               {% for c in categories %}
               <li class="list-group-item text-light">{{ c }}</li>
               {% endfor %}
@@ -57,7 +57,7 @@
     <!-- Transactions Card -->
     <div class="card">
       <div class="card-body">
-        <h2 class="card-title">Your Transactions</h2>
+        <h4 class="card-title">Your Transactions</h4>
         <div class="mb-3">
           <a href="{% url 'add_transaction' %}" class="btn btn-primary">Add Transaction</a>
           <a href="{% url 'upload_transaction' %}" class="btn btn-secondary">Import Transactions</a>


### PR DESCRIPTION
added field to display total money spent

Since the 'Tracked Expenses Category' card is hardcoded to a set height currently, I had to change the size of some headings and adjust some vertical margins to make the card still line up with the bottom of the chart, because adding the 'Total Money Spent' field increased the height of the cards.

For better compatibility with new changes in the future, it would be useful to not hardcode the height of the 'Tracked Expenses Category' card and make the cards automatically adjust in size to stay in line with the graph card.
![Screenshot 2024-03-21 002403](https://github.com/benglish24/Group5BudgetBuddy/assets/96104498/278ad049-2fa7-49cb-905a-5c1bcd7835b2)
