### PR TITLE
Fix delete category button

### DIFF
--- a/budget-buddy/user_dashboard/forms.py
+++ b/budget-buddy/user_dashboard/forms.py
@@ -36,6 +36,18 @@ class CategoryForm(ModelForm):
         model = Category
         fields = ['name']
 
+from django import forms
+from .models import Category
+
+class CategoryReplacementForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        current_category = kwargs.pop('current_category', None)
+        super(CategoryReplacementForm, self).__init__(*args, **kwargs)
+        self.fields['replacement_category'].queryset = Category.objects.exclude(id=current_category.id)
+
+    replacement_category = forms.ModelChoiceField(queryset=Category.objects.all(), label='Replacement Category')
+
+
 class SalaryForm(ModelForm):
     class Meta:
         model = UserDashboard

--- a/budget-buddy/user_dashboard/templates/cannot_delete_category.html
+++ b/budget-buddy/user_dashboard/templates/cannot_delete_category.html
@@ -17,4 +17,12 @@
         <button type="submit" class="btn btn-primary">Replace Transactions</button>
         <a href="{% url 'user_dash' %}" class="btn btn-secondary">Cancel</a>
     </form>
+
+    <hr> <!-- Add a horizontal rule to visually separate the two forms -->
+
+    <p>Alternatively, you can delete the category and its associated transactions:</p>
+    <form action="{% url 'delete_transactions' category.id %}" method="post">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-danger">Delete Transactions</button>
+    </form>
 {% endblock content %}

--- a/budget-buddy/user_dashboard/templates/cannot_delete_category.html
+++ b/budget-buddy/user_dashboard/templates/cannot_delete_category.html
@@ -1,0 +1,20 @@
+{% extends "base_generic.html" %}
+{% block title %}
+    Cannot Delete Category
+{% endblock title %}
+{% block content %}
+    <h1>Cannot Delete Category</h1>
+    <p>The category "{{ category.name }}" cannot be deleted because it is used in the following transactions:</p>
+    <ul>
+        {% for transaction in transactions %}
+            <li>{{ transaction }}</li>
+        {% endfor %}
+    </ul>
+    <p>Please choose a new category for the affected transactions:</p>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" class="btn btn-primary">Replace Transactions</button>
+        <a href="{% url 'user_dash' %}" class="btn btn-secondary">Cancel</a>
+    </form>
+{% endblock content %}

--- a/budget-buddy/user_dashboard/templates/category_form.html
+++ b/budget-buddy/user_dashboard/templates/category_form.html
@@ -1,1 +1,41 @@
-{% include 'generic_create_update_form.html' %}
+{% extends "base_generic.html" %}
+{% load django_bootstrap5 %}
+{% block title %}
+    Add Category
+{% endblock title %}
+{% block content %}
+    <!-- Form for adding a category -->
+    <div class="d-flex justify-content-center">
+        <div class="col-md-4">
+            <form method="post" id="categoryForm">
+                {% csrf_token %}
+                <div class="form-group">
+                    {{ form.name.label_tag }}
+                    <!-- Textarea for category name with limited rows and maximum length -->
+                    <textarea class="form-control" name="name" id="id_name" rows="1" maxlength="255" placeholder="Enter category name..."></textarea>
+                </div>
+                {{ form.media }}
+                <!-- Submit button -->
+                <div class="text-center">
+                    <button type="submit" class="btn btn-primary">{{ button_text }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <!-- Script to prevent new lines in the textarea -->
+    <script>
+        // Wait for the DOM content to be fully loaded
+        document.addEventListener('DOMContentLoaded', function() {
+            // Get the textarea element
+            var textarea = document.getElementById('id_name');
+            // Add event listener for keydown event
+            textarea.addEventListener('keydown', function(event) {
+                // Check if the pressed key is the enter key
+                if (event.keyCode === 13) {
+                    // Prevent default behavior (creating new line)
+                    event.preventDefault();
+                }
+            });
+        });
+    </script>
+{% endblock content %}

--- a/budget-buddy/user_dashboard/templates/category_form.html
+++ b/budget-buddy/user_dashboard/templates/category_form.html
@@ -15,8 +15,8 @@
                     <textarea class="form-control" name="name" id="id_name" rows="1" maxlength="255" placeholder="Enter category name..."></textarea>
                 </div>
                 {{ form.media }}
-                <!-- Submit button -->
-                <div class="text-center">
+                <!-- Add a margin between the text box and the submit button -->
+                <div class="mt-2 text-center">
                     <button type="submit" class="btn btn-primary">{{ button_text }}</button>
                 </div>
             </form>

--- a/budget-buddy/user_dashboard/templates/user_dash.html
+++ b/budget-buddy/user_dashboard/templates/user_dash.html
@@ -11,49 +11,56 @@
   <div class="card-body">
     <div class="row">
       <!-- Left Column -->
-      <div class="col-md-6">
-        <!-- Account Overview Card -->
-        <div class="card mb-3">
-          <div class="card-body">
-            <h4 class="card-title">Account Overview:</h4>
-            <ul class="list-group">
-              <li class="list-group-item text-light">Salary: ${{ dashboard.salary|floatformat:2|intcomma }}</li>
-              <li class="list-group-item text-light">Saving Percentage: {{ dashboard.saving_percentage }}%</li>
-              <li class="list-group-item text-light">Fixed Percentage: {{ dashboard.fixed_percentage }}%</li>
-              <li class="list-group-item text-light">Available to Spend: ${{ dashboard.spending|floatformat:2|intcomma }}</li>
-              <li class="list-group-item text-light">Total Money Spent: ${{ total_amount|floatformat:2|intcomma }}</li>
-            </ul>
-            <a href="{% url 'update_information' %}" class="btn btn-primary btn-sm mt-2">Update Information</a>
+      <div class="col-md-6 d-flex flex-column">
+          <!-- Account Overview Card -->
+          <div class="card mb-3 flex-grow-1">
+              <div class="card-body">
+                  <h4 class="card-title">Account Overview:</h4>
+                  <ul class="list-group">
+                      <li class="list-group-item text-light">Salary: ${{ dashboard.salary|floatformat:2|intcomma }}</li>
+                      <li class="list-group-item text-light">Saving Percentage: {{ dashboard.saving_percentage }}%</li>
+                      <li class="list-group-item text-light">Fixed Percentage: {{ dashboard.fixed_percentage }}%</li>
+                      <li class="list-group-item text-light">Available to Spend: ${{ dashboard.spending|floatformat:2|intcomma }}</li>
+                      <li class="list-group-item text-light">Total Money Spent: ${{ total_amount|floatformat:2|intcomma }}</li>
+                  </ul>
+                  <a href="{% url 'update_information' %}" class="btn btn-primary btn-sm mt-2">Update Information</a>
+              </div>
           </div>
-        </div>
-        
-        <!-- Tracked Categories Card -->
-        <div class="card mb-2">
-          <div class="card-body">
-            <h4 class="card-title">Your Tracked Expense Categories</h4>
-            <ul class="list-group mb-2"  style="height: 209px; overflow-y: auto;">
-              {% for c in categories %}
-              <li class="list-group-item text-light">{{ c }}</li>
-              {% endfor %}
-            </ul>
-            <a href="{% url 'add_category' %}" class="btn btn-primary btn-sm">Add Category</a>
-            <a href="{% url 'add_category' %}" class="btn btn-danger btn-sm">Remove Category</a>
+
+          <!-- Tracked Categories Card -->
+          <div class="card mb-2 flex-grow-1">
+              <div class="card-body">
+                  <h4 class="card-title">Your Tracked Expense Categories</h4>
+                  <ul class="list-group mb-2" style="height: 209px; overflow-y: auto;">
+                      {% for category in categories %}
+                      <li class="list-group-item d-flex justify-content-between align-items-center text-light">
+                          {{ category }}
+                          <form method="post" action="{% url 'delete_category' category.id %}">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-sm btn-danger">
+                                <i class="fas fa-trash-alt"></i> <!-- Font Awesome delete icon -->
+                            </button>
+                        </form>
+                      </li>
+                      {% endfor %}
+                  </ul>
+                  <a href="{% url 'add_category' %}" class="btn btn-primary btn-sm">Add Category</a>
+              </div>
           </div>
-        </div>
       </div>
-      
+
       <!-- Right Column -->
-      <div class="col-md-6">
-        <!-- Expense Overview Chart Card -->
-        <div class="card mb-4">
-          <div class="card-body">
-            <h3 class="card-title">Expense Overview:</h3>
-            <canvas id="doughnutChart" width="250" height="250"></canvas>
+      <div class="col-md-6 d-flex flex-column">
+          <!-- Expense Overview Chart Card -->
+          <div class="card mb-4 flex-grow-1">
+              <div class="card-body">
+                  <h3 class="card-title">Expense Overview:</h3>
+                  <canvas id="doughnutChart" width="250" height="250"></canvas>
+              </div>
           </div>
-        </div>
       </div>
-    </div>
-    
+  </div>
+
     <!-- Transactions Card -->
     <div class="card">
       <div class="card-body">

--- a/budget-buddy/user_dashboard/urls.py
+++ b/budget-buddy/user_dashboard/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path('upload_transaction/', upload_transaction, name='upload_transaction'),
     path('add_category/', add_category, name='add_category'),
     path('delete_category/<int:category_id>/', delete_category, name='delete_category'),
+    path('delete_transactions/<int:category_id>/', delete_transactions, name='delete_transactions'),
     path('update_information/', update_information, name='update_information')
 ]

--- a/budget-buddy/user_dashboard/urls.py
+++ b/budget-buddy/user_dashboard/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     path('delete_transaction/<int:pk>', delete_transaction, name='delete_transaction'),
     path('upload_transaction/', upload_transaction, name='upload_transaction'),
     path('add_category/', add_category, name='add_category'),
+    path('delete_category/<int:category_id>/', delete_category, name='delete_category'),
     path('update_information/', update_information, name='update_information')
 ]

--- a/budget-buddy/user_dashboard/views.py
+++ b/budget-buddy/user_dashboard/views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 from django.shortcuts import render, redirect
-from django.db.models import Sum 
+from django.db.models import Sum
+from django.contrib import messages
 
 from .models import UserDashboard, Transaction, Category
 from .decorators import authenticated_user
@@ -23,7 +24,7 @@ def user_dashboard(request):
 
     dct = defaultdict(int)
 
-    # Calculate total transaction amount for current user 
+    # Calculate total transaction amount for current user
     total_amount = transactions.aggregate(total_amount=Sum('amount'))['total_amount'] or 0
 
     for t in transactions:
@@ -149,13 +150,21 @@ def add_category(request):
     if request.method == 'POST':
         form = CategoryForm(request.POST)
         if form.is_valid():
+            category_name = form.cleaned_data['name']
+            # Check if a category with the same name already exists
+            if Category.objects.filter(name=category_name, user=request.user).exists():
+                # If it exists, display a warning message
+                messages.warning(request, 'Category with this name already exists.')
+                return redirect('add_category')  # Redirect back to the add category page
+
+            # If the category doesn't exist, proceed to save it
             category = form.save(commit=False)
             category.user = request.user
             category.save()
             return redirect('/')
 
     form = CategoryForm()
-    context = {'form' : form, 'button_text' : 'Confirm'}
+    context = {'form': form, 'button_text': 'Confirm'}
     return render(request, 'category_form.html', context)
 
 def update_information(request):

--- a/budget-buddy/user_dashboard/views.py
+++ b/budget-buddy/user_dashboard/views.py
@@ -172,19 +172,24 @@ def delete_category(request, category_id):
     category = Category.objects.get(id=category_id)
     transactions_with_category = Transaction.objects.filter(category=category)
 
-    if request.method == 'POST':
-        form = CategoryReplacementForm(request.POST, current_category=category)
-        if form.is_valid():
-            replacement_category = form.cleaned_data['replacement_category']
-            # Replace transactions with the selected replacement category
-            Transaction.objects.filter(category=category).update(category=replacement_category)
-            # Delete the category
-            category.delete()
-            return redirect('user_dash')
-    else:
-        form = CategoryReplacementForm(current_category=category)
+    if transactions_with_category.exists():
+        if request.method == 'POST':
+            form = CategoryReplacementForm(request.POST, current_category=category)
+            if form.is_valid():
+                replacement_category = form.cleaned_data['replacement_category']
+                # Replace transactions with the selected replacement category
+                Transaction.objects.filter(category=category).update(category=replacement_category)
+                # Delete the category
+                category.delete()
+                return redirect('user_dash')
+        else:
+            form = CategoryReplacementForm(current_category=category)
 
-    return render(request, 'cannot_delete_category.html', {'category': category, 'form': form, 'transactions': transactions_with_category})
+        return render(request, 'cannot_delete_category.html', {'category': category, 'form': form, 'transactions': transactions_with_category})
+    else:
+        # No transactions associated with the category, delete it directly
+        category.delete()
+        return redirect('user_dash')
 
 @authenticated_user
 def delete_transactions(request, category_id):

--- a/budget-buddy/user_dashboard/views.py
+++ b/budget-buddy/user_dashboard/views.py
@@ -187,6 +187,22 @@ def delete_category(request, category_id):
     return render(request, 'cannot_delete_category.html', {'category': category, 'form': form, 'transactions': transactions_with_category})
 
 @authenticated_user
+def delete_transactions(request, category_id):
+    category = Category.objects.get(id=category_id)
+    transactions_with_category = Transaction.objects.filter(category=category)
+
+    if request.method == 'POST':
+        # Delete transactions associated with the category
+        transactions_with_category.delete()
+
+        # Delete the category
+        category.delete()
+
+        return redirect('user_dash')
+
+    return render(request, 'delete_transactions.html', {'category': category, 'transactions': transactions_with_category})
+
+@authenticated_user
 def update_information(request):
     dashboard = UserDashboard.objects.get(custom_user=request.user)
     if request.method == 'POST':


### PR DESCRIPTION
Things Changed:

- Better 'add category' page
- User dashboard page modified to be more intuitive when deleting categories
- Categories that have no use in transactions can be deleted instantly
- Categories with uses in the transaction table have 2 options when getting deleted:
    - Replace the transactions with a new categories(beside the one getting deleted)
    - Delete the category and its associated transactions